### PR TITLE
Fix core training correctness

### DIFF
--- a/cmn_ai/callbacks/schedule.py
+++ b/cmn_ai/callbacks/schedule.py
@@ -90,8 +90,7 @@ def annealer(func: Callable):
     >>> scheduler = my_scheduler(0.1, 0.01)
     >>> value = scheduler(0.5)  # pos = 0.5
     """
-    wraps(func)
-
+    @wraps(func)
     def annealer_wrapper(*args, **kwargs):
         return partial(func, *args, **kwargs)
 

--- a/cmn_ai/callbacks/training.py
+++ b/cmn_ai/callbacks/training.py
@@ -932,19 +932,26 @@ class Mixup(Callback):
         Apply mixup transformation to batch inputs and targets.
 
         The mixup process involves:
-        1. Drawing samples from a beta distribution for each image
+        1. Drawing samples from a beta distribution for each item
         2. Taking the maximum of λ and 1-λ to avoid identical combinations
         3. Shuffling the batch for combination
         4. Creating linear combinations of inputs and targets
         """
-        λ = self.distrib.sample((len(self.xb),)).to(self.xb[0].device)
-        λ = torch.stack([λ, 1 - λ], dim=1)
-        self.λ = λ.max(1)[0].view(-1, 1, 1, 1)
-        shuffle = torch.randperm(len(self.xb[0]))
-        self.learner.xb = [
-            x * self.λ + x[shuffle] * (1 - self.λ) for x in self.xb
-        ]
-        self.yb1 = [y[shuffle] for y in self.yb]
+        bs = self.xb[0].size(0)
+        λ = self.distrib.sample((bs,)).squeeze(-1).to(self.xb[0].device)
+        self.λ = torch.stack([λ, 1 - λ], dim=1).max(1)[0]
+        shuffle = torch.randperm(bs, device=self.xb[0].device)
+
+        mixed_xb = []
+        for x in self.xb:
+            lam = self.λ.to(x.device).view(
+                -1, *([1] * (x.dim() - 1))
+            )
+            idx = shuffle.to(x.device)
+            mixed_xb.append(x * lam + x[idx] * (1 - lam))
+
+        self.learner.xb = mixed_xb
+        self.yb1 = [y[shuffle.to(y.device)] for y in self.yb]
 
     def loss_func(self, pred: torch.Tensor, yb: torch.Tensor) -> torch.Tensor:
         """
@@ -967,7 +974,10 @@ class Mixup(Callback):
         with NoneReduce(self.old_loss_func) as loss_func:
             loss1 = loss_func(pred, yb)
             loss2 = loss_func(pred, *self.yb1)
-        loss = loss1 * self.λ + loss2 * (1 - self.λ)
+        λ = self.λ.to(loss1.device)
+        if loss1.dim() > 0:
+            λ = λ.view(-1, *([1] * (loss1.dim() - 1)))
+        loss = loss1 * λ + loss2 * (1 - λ)
         return reduce_loss(
             loss, getattr(self.old_loss_func, "reduction", "mean")
         )

--- a/cmn_ai/utils/processors.py
+++ b/cmn_ai/utils/processors.py
@@ -89,9 +89,8 @@ cmn_ai.text.data : Text data handling utilities
 from __future__ import annotations
 
 from collections import Counter
-from typing import Dict, List
 
-from .utils import listify, uniqueify
+from .utils import listify
 
 
 class Processor:
@@ -228,8 +227,8 @@ class NumericalizeProcessor(Processor):
                 reserved_set.add(token)
                 remaining_slots -= 1
 
-        # Build final vocabulary (uniqueify and sort)
-        self.vocab = uniqueify(vocab_tokens, sort=True)
+        # Preserve the priority order built above while defensively deduping.
+        self.vocab = list(dict.fromkeys(vocab_tokens))
 
         self._create_mappings()
         self._is_fitted = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.13"
-license = {text = "MIT"}
+license = "Apache-2.0"
 keywords = ["machine-learning", "deep-learning", "vision", "text", "tabular"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/tests/test_callbacks/test_schedule.py
+++ b/tests/test_callbacks/test_schedule.py
@@ -45,6 +45,18 @@ class TestSchedulerFunctions:
         assert abs(scheduler(1.0) - 0.01) < 1e-10  # end
         assert abs(scheduler(0.5) - 0.055) < 1e-10  # middle
 
+    def test_annealer_preserves_wrapped_metadata(self):
+        """Test that annealer preserves scheduler metadata."""
+
+        @annealer
+        def test_scheduler(start, end, pos):
+            """Linearly interpolate for tests."""
+            return start + (end - start) * pos
+
+        assert test_scheduler.__name__ == "test_scheduler"
+        assert test_scheduler.__doc__ == "Linearly interpolate for tests."
+        assert lin_sched.__name__ == "lin_sched"
+
     def test_no_sched(self):
         """Test no_sched function."""
         scheduler = no_sched(0.1, 0.01)

--- a/tests/test_callbacks/test_training.py
+++ b/tests/test_callbacks/test_training.py
@@ -663,6 +663,9 @@ class TestMixup:
         # Should create mixup weights and shuffled targets
         assert hasattr(mixup, "λ")
         assert hasattr(mixup, "yb1")
+        assert mixup.λ.shape == (4,)
+        assert mock_learner.xb[0].shape == torch.Size([4, 10])
+        assert mixup.yb1[0].shape == torch.Size([4, 1])
 
     def test_mixup_loss_func(self):
         """Test Mixup loss_func method."""
@@ -691,3 +694,23 @@ class TestMixup:
 
         # Should return a tensor
         assert isinstance(result, torch.Tensor)
+
+    def test_mixup_loss_func_broadcasts_lambda_over_feature_losses(self):
+        """Test Mixup loss broadcasts per-example weights over features."""
+        mixup = Mixup()
+
+        mock_learner = MagicMock()
+        mock_learner.loss_func = nn.MSELoss(reduction="mean")
+        mock_learner.training = True
+
+        mixup.set_learner(mock_learner)
+        mixup.before_fit()
+
+        pred = torch.zeros(4, 2)
+        yb = torch.zeros(4, 2)
+        mixup.yb1 = [torch.ones(4, 2)]
+        mixup.λ = torch.tensor([0.2, 0.4, 0.6, 0.8])
+
+        result = mixup.loss_func(pred, yb)
+
+        assert torch.allclose(result, torch.tensor(0.5))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,23 @@
+"""Tests for package metadata."""
+
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_project_license_metadata_matches_license_file() -> None:
+    """Test pyproject license metadata matches the Apache license file."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    project = pyproject["project"]
+
+    assert "Apache License" in (ROOT / "LICENSE").read_text()
+    assert project["license"] == "Apache-2.0"
+    assert (
+        "License :: OSI Approved :: Apache Software License"
+        in project["classifiers"]
+    )
+    assert "License :: OSI Approved :: MIT License" not in project[
+        "classifiers"
+    ]

--- a/tests/test_utils/test_processors.py
+++ b/tests/test_utils/test_processors.py
@@ -308,16 +308,35 @@ class TestNumericalizeProcessor:
         assert all(isinstance(x, int) for x in result2)
         assert all(isinstance(x, int) for x in result3)
 
-    def test_vocabulary_ordering(self) -> None:
-        """Test that vocabulary is properly ordered."""
-        processor = NumericalizeProcessor(min_freq=1)
-        tokens = [["world", "hello", "there"]]
+    def test_vocabulary_preserves_priority_order(self) -> None:
+        """Test that vocabulary preserves unk/reserved/frequency order."""
+        processor = NumericalizeProcessor(
+            min_freq=1, reserved_tokens=["<pad>", "<eos>"]
+        )
+        tokens = [
+            ["zeta", "alpha", "zeta", "beta"],
+            ["zeta", "alpha", "beta", "gamma"],
+            ["zeta", "alpha"],
+        ]
+
         processor.fit(tokens)
 
-        # Vocabulary should be sorted
-        vocab = processor.vocab
-        assert vocab[0] == "<unk>"  # unk_token should be first
-        assert vocab == sorted(vocab)  # Rest should be sorted
+        assert processor.vocab == [
+            "<unk>",
+            "<pad>",
+            "<eos>",
+            "zeta",
+            "alpha",
+            "beta",
+            "gamma",
+        ]
+        assert processor.unk_idx == 0
+
+        in_vocab_tokens = ["zeta", "alpha", "beta", "gamma"]
+        assert (
+            processor.deprocess(processor.process(in_vocab_tokens))
+            == in_vocab_tokens
+        )
 
     def test_max_vocab_limit(self) -> None:
         """Test that max_vocab limit is respected."""


### PR DESCRIPTION
## Summary
- Preserve numericalizer vocabulary ordering so unknown and reserved tokens keep stable indices.
- Preserve annealer function metadata.
- Sample mixup lambdas per example.
- Align package license metadata with Apache-2.0.