### PR TITLE
Align learner public API and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ pip install cmn-ai
 ```bash
 git clone https://github.com/ImadDabbura/cmn_ai.git
 cd cmn_ai
-pip install poetry
-poetry install
+uv sync --extra dev
 ```
 
 ## Quick Start
@@ -78,14 +77,14 @@ poetry install
 
 ```python
 from cmn_ai.learner import Learner
-from cmn_ai.callbacks.training import DeviceCallBack, Recorder
+from cmn_ai.callbacks.training import DeviceCallback, Recorder
 
 # Create a learner with callbacks
 learner = Learner(model, dls, loss_func, opt_func, callbacks=[Recorder("lr")])
-learner.add_callback(DeviceCallBack("cuda:0"))
+learner.add_callback(DeviceCallback("cuda:0"))
 
 # Train your model
-learner.fit(epochs=10, lr=1e-3)
+learner.fit(n_epochs=10, lr=1e-3)
 ```
 
 ### Vision Tasks
@@ -96,7 +95,7 @@ from cmn_ai.vision import VisionLearner
 # Vision-specific learner with built-in utilities
 vision_learner = VisionLearner(model, dls, loss_func)
 vision_learner.show_batch()  # Visualize training data
-vision_learner.fit(epochs=20, lr=1e-4)
+vision_learner.fit(n_epochs=20, lr=1e-4)
 ```
 
 ### Tabular Data Processing
@@ -121,7 +120,6 @@ tfm.fit_transform(X_train, y_train)
 The `Learner` class provides a flexible foundation for training deep learning models with:
 
 - Exception-based callback system for fine-grained training control
-- Automatic mixed precision support
 - Built-in logging and metrics tracking
 - Memory optimization utilities
 
@@ -166,11 +164,11 @@ learner.add_callbacks(
     [
         ProgressCallback(),
         BatchScheduler(sched),
-        MetricsCallback(accuracy=MulticlassAccuracy(nm_classes=10)),
+        MetricsCallback(accuracy=MulticlassAccuracy(num_classes=10)),
     ]
 )
 
-learner.fit(epochs=50, lr=1e-3)
+learner.fit(n_epochs=50, lr=1e-3)
 ```
 
 ### Custom Callback Creation
@@ -202,20 +200,20 @@ class CustomCallback(Callback):
 ```bash
 git clone https://github.com/ImadDabbura/cmn_ai.git
 cd cmn_ai
-poetry install
+uv sync --extra dev
 ```
 
 ### Run Tests
 
 ```bash
 # Full test suite
-poetry run pytest
+uv run pytest
 
 # With coverage
-poetry run pytest --cov=cmn_ai
+uv run pytest --cov=cmn_ai
 
 # Specific test file
-poetry run pytest tests/test_learner.py
+uv run pytest tests/test_learner.py
 ```
 
 ### Code Quality

--- a/cmn_ai/activations.py
+++ b/cmn_ai/activations.py
@@ -44,14 +44,15 @@ class GeneralRelu(nn.Module):
 
     Parameters
     ----------
-    leak : float, optional
+    leak : float or None, default=0.1
         Negative slope for values less than zero, similar to LeakyReLU.
-        If None (default), standard ReLU behavior is used (all negatives set to 0).
-    sub : float, optional
-        A constant value to subtract from the activation output after applying ReLU/LeakyReLU.
-        If None (default), no subtraction is applied.
-    maxv : float, optional
-        Maximum value to clip the activation output to. If None (default), no clipping is applied.
+        If None, standard ReLU behavior is used (all negatives set to 0).
+    sub : float or None, default=0.4
+        A constant value to subtract from the activation output after applying
+        ReLU/LeakyReLU. If None, no subtraction is applied.
+    maxv : float or None, default=None
+        Maximum value to clip the activation output to. If None, no clipping
+        is applied.
 
     Attributes
     ----------
@@ -70,7 +71,7 @@ class GeneralRelu(nn.Module):
     Examples
     --------
     >>> import torch
-    >>> act = GeneralReLU(leak=0.1, sub=0.4, maxv=6.0)
+    >>> act = GeneralRelu(leak=0.1, sub=0.4, maxv=6.0)
     >>> x = torch.tensor([-2.0, -0.5, 0.5, 2.0])
     >>> act(x)
     tensor([-0.6000, -0.4500,  0.1000,  1.6000])

--- a/cmn_ai/callbacks/training.py
+++ b/cmn_ai/callbacks/training.py
@@ -53,7 +53,7 @@ Basic training with device management and progress tracking:
 ... ]
 >>>
 >>> # Add to learner
->>> learner.add_cbs(callbacks)
+>>> learner.add_callbacks(callbacks)
 
 Learning rate finding:
 
@@ -61,7 +61,7 @@ Learning rate finding:
 >>>
 >>> # Find optimal learning rate
 >>> lr_finder = LRFinder(gamma=1.3, num_iter=100, stop_div=True)
->>> learner.add_cb(lr_finder)
+>>> learner.add_callback(lr_finder)
 >>> learner.fit(1)  # Run for 1 epoch
 >>> lr_finder.recorder.plot()  # Plot lr vs loss
 
@@ -71,7 +71,7 @@ Data augmentation with mixup:
 >>>
 >>> # Add mixup augmentation
 >>> mixup = Mixup(alpha=0.4)
->>> learner.add_cb(mixup)
+>>> learner.add_callback(mixup)
 >>> learner.fit(10)
 
 Metrics tracking:
@@ -82,7 +82,7 @@ Metrics tracking:
 >>> # Track accuracy during training
 >>> accuracy = MulticlassAccuracy()
 >>> metrics_cb = MetricsCallback(accuracy=accuracy)
->>> learner.add_cb(metrics_cb)
+>>> learner.add_callback(metrics_cb)
 >>> learner.fit(5)
 
 Debugging with single batch:
@@ -91,7 +91,7 @@ Debugging with single batch:
 >>>
 >>> # Run only one batch for debugging
 >>> debug_cb = SingleBatchCallback()
->>> learner.add_cb(debug_cb)
+>>> learner.add_callback(debug_cb)
 >>> learner.fit(1)  # Will stop after first batch
 
 Raises

--- a/cmn_ai/learner.py
+++ b/cmn_ai/learner.py
@@ -107,6 +107,7 @@ from __future__ import annotations
 
 import pickle
 from collections.abc import Callable, Iterable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -128,6 +129,7 @@ from .callbacks.core import (
     CancelTrainException,
     CancelValidateException,
 )
+from .callbacks.schedule import BatchScheduler
 from .callbacks.training import (
     LRFinder,
     ProgressCallback,
@@ -384,6 +386,36 @@ class Learner:
             self._with_events(self._fit, "fit", CancelFitException)
         finally:
             self._remove_callbacks(callbacks)
+
+    def fit_one_cycle(
+        self,
+        n_epochs: int = 1,
+        max_lr: float = 1e-2,
+        callbacks: Iterable[Callback] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Fit the model using PyTorch's one-cycle learning rate schedule.
+
+        Parameters
+        ----------
+        n_epochs : int, default=1
+            Number of epochs to train the model.
+        max_lr : float, default=1e-2
+            Upper learning rate bound passed to `OneCycleLR`.
+        callbacks : Iterable[Callback] | None, default=None
+            Additional callbacks to include during training.
+        **kwargs : Any
+            Additional keyword arguments passed to `fit`.
+        """
+        total_steps = n_epochs * len(self.dls.train)
+        sched = partial(
+            opt.lr_scheduler.OneCycleLR,
+            max_lr=max_lr,
+            total_steps=total_steps,
+        )
+        callbacks = [BatchScheduler(sched)] + listify(callbacks)
+        self.fit(n_epochs=n_epochs, callbacks=callbacks, **kwargs)
 
     def lr_find(
         self,

--- a/cmn_ai/learner.py
+++ b/cmn_ai/learner.py
@@ -24,7 +24,7 @@ A callback can implement actions on the following events:
   said batch. It can be used to do any setup necessary for the batch
   (like hyper-parameter scheduling) or to change the input/target before
   it goes in the model (change of the input with techniques like mixup)
-- `after_pred`: Called after computing the output of the model on the batch.
+- `after_predict`: Called after computing the output of the model on the batch.
   It can be used to change that output before it's fed to the loss function
 - `after_loss`: Called after the loss has been computed, but before the
   backward pass. It can be used to add any penalty to the loss
@@ -52,6 +52,11 @@ A callback can implement actions on the following events:
 - `after_cancel_fit`: Reached immediately after `CancelFitException`
   before proceeding to `after_fit`
 - `after_fit`: Called at the end of training, for any final clean-up
+
+Only the phases executed through `_with_events` have `before_*` and
+`after_cancel_*` event variants: fit, epoch, train, validate, batch, backward,
+and step. The direct `after_predict` and `after_loss` callbacks do not have
+matching `before_` or `after_cancel_` events.
 
 Classes
 -------

--- a/cmn_ai/learner.py
+++ b/cmn_ai/learner.py
@@ -545,11 +545,27 @@ class Learner:
                 added_callbacks.append(cb)
         return added_callbacks
 
+    def add_callback(self, cb: Callback) -> None:
+        """Add a callback to the learner."""
+        self._add_callbacks([cb])
+
+    def add_callbacks(self, cbs: Iterable[Callback] | None) -> None:
+        """Add callbacks to the learner."""
+        self._add_callbacks(cbs)
+
     def _remove_callbacks(self, cbs: Iterable[Callback] | None) -> None:
         """Remove callbacks from the learner."""
         for cb in listify(cbs):
             delattr(self, cb.name)
             self.callbacks.remove(cb)
+
+    def remove_callback(self, cb: Callback) -> None:
+        """Remove a callback from the learner."""
+        self._remove_callbacks([cb])
+
+    def remove_callbacks(self, cbs: Iterable[Callback] | None) -> None:
+        """Remove callbacks from the learner."""
+        self._remove_callbacks(cbs)
 
     def _callback(self, event_nm: str) -> None:
         """Execute all callbacks for a given event."""

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,7 @@ pip install cmn-ai
 ```bash
 git clone https://github.com/ImadDabbura/cmn_ai.git
 cd cmn_ai
-pip install poetry
-poetry install
+uv sync --extra dev
 ```
 
 ## Quick Start
@@ -68,14 +67,14 @@ poetry install
 
 ```python
 from cmn_ai.learner import Learner
-from cmn_ai.callbacks.training import DeviceCallBack, Recorder
+from cmn_ai.callbacks.training import DeviceCallback, Recorder
 
 # Create a learner with callbacks
 learner = Learner(model, dls, loss_func, opt_func, callbacks=[Recorder("lr")])
-learner.add_callback(DeviceCallBack("cuda:0"))
+learner.add_callback(DeviceCallback("cuda:0"))
 
 # Train your model
-learner.fit(epochs=10, lr=1e-3)
+learner.fit(n_epochs=10, lr=1e-3)
 ```
 
 ### Vision Tasks
@@ -86,7 +85,7 @@ from cmn_ai.vision import VisionLearner
 # Vision-specific learner with built-in utilities
 vision_learner = VisionLearner(model, dls, loss_func)
 vision_learner.show_batch()  # Visualize training data
-vision_learner.fit(epochs=20, lr=1e-4)
+vision_learner.fit(n_epochs=20, lr=1e-4)
 ```
 
 ### Tabular Data Processing
@@ -111,7 +110,6 @@ tfm.fit_transform(X_train, y_train)
 The `Learner` class provides a flexible foundation for training deep learning models with:
 
 - Exception-based callback system for fine-grained training control
-- Automatic mixed precision support
 - Built-in logging and metrics tracking
 - Memory optimization utilities
 
@@ -156,11 +154,11 @@ learner.add_callbacks(
     [
         ProgressCallback(),
         BatchScheduler(sched),
-        MetricsCallback(accuracy=MulticlassAccuracy(nm_classes=10)),
+        MetricsCallback(accuracy=MulticlassAccuracy(num_classes=10)),
     ]
 )
 
-learner.fit(epochs=50, lr=1e-3)
+learner.fit(n_epochs=50, lr=1e-3)
 ```
 
 ### Custom Callback Creation
@@ -192,20 +190,20 @@ class CustomCallback(Callback):
 ```bash
 git clone https://github.com/ImadDabbura/cmn_ai.git
 cd cmn_ai
-poetry install
+uv sync --extra dev
 ```
 
 ### Run Tests
 
 ```bash
 # Full test suite
-poetry run pytest
+uv run pytest
 
 # With coverage
-poetry run pytest --cov=cmn_ai
+uv run pytest --cov=cmn_ai
 
 # Specific test file
-poetry run pytest tests/test_learner.py
+uv run pytest tests/test_learner.py
 ```
 
 ### Code Quality

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -19,6 +19,7 @@ from cmn_ai.callbacks.core import (
     CancelEpochException,
     CancelFitException,
 )
+from cmn_ai.callbacks.schedule import BatchScheduler
 from cmn_ai.callbacks.training import TrainEvalCallback
 from cmn_ai.learner import Learner, params_getter
 from cmn_ai.utils.data import DataLoaders
@@ -219,6 +220,34 @@ class TestLearnerTraining:
             # Callback should be removed after fit
             assert test_callback not in learner.callbacks
             assert not hasattr(learner, test_callback.name)
+
+    def test_fit_one_cycle_adds_batch_scheduler(self, learner):
+        """Test fit_one_cycle delegates to fit with a OneCycle batch scheduler."""
+        test_callback = TestCallback()
+
+        with patch.object(learner, "fit") as mock_fit:
+            learner.fit_one_cycle(
+                n_epochs=2,
+                max_lr=0.05,
+                callbacks=[test_callback],
+                lr=0.001,
+                run_valid=False,
+            )
+
+        mock_fit.assert_called_once()
+        kwargs = mock_fit.call_args.kwargs
+        callbacks = kwargs["callbacks"]
+
+        assert kwargs["n_epochs"] == 2
+        assert kwargs["lr"] == 0.001
+        assert kwargs["run_valid"] is False
+        assert isinstance(callbacks[0], BatchScheduler)
+        assert callbacks[0].scheduler.func is torch.optim.lr_scheduler.OneCycleLR
+        assert callbacks[0].scheduler.keywords["max_lr"] == 0.05
+        assert callbacks[0].scheduler.keywords["total_steps"] == 2 * len(
+            learner.dls.train
+        )
+        assert callbacks[1] is test_callback
 
 
 class TestLearnerTrainingMode:

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -404,6 +404,28 @@ class TestLearnerCallbacks:
         assert hasattr(learner, test_callback.name)
         assert getattr(learner, test_callback.name) == test_callback
 
+    def test_add_callback_public_api(self, learner):
+        """Test adding a single callback through the public API."""
+        test_callback = TestCallback()
+
+        learner.add_callback(test_callback)
+
+        assert test_callback in learner.callbacks
+        assert hasattr(learner, test_callback.name)
+        assert getattr(learner, test_callback.name) == test_callback
+
+    def test_add_callbacks_public_api(self, learner):
+        """Test adding multiple callbacks through the public API."""
+        callback1 = TestCallback()
+        callback2 = TestCallback2()
+
+        learner.add_callbacks([callback1, callback2])
+
+        assert callback1 in learner.callbacks
+        assert callback2 in learner.callbacks
+        assert hasattr(learner, callback1.name)
+        assert hasattr(learner, callback2.name)
+
     def test_remove_callbacks(self, learner):
         """Test removing callbacks from learner."""
         test_callback = TestCallback()
@@ -413,6 +435,29 @@ class TestLearnerCallbacks:
 
         assert test_callback not in learner.callbacks
         assert not hasattr(learner, test_callback.name)
+
+    def test_remove_callback_public_api(self, learner):
+        """Test removing a single callback through the public API."""
+        test_callback = TestCallback()
+        learner._add_callbacks([test_callback])
+
+        learner.remove_callback(test_callback)
+
+        assert test_callback not in learner.callbacks
+        assert not hasattr(learner, test_callback.name)
+
+    def test_remove_callbacks_public_api(self, learner):
+        """Test removing multiple callbacks through the public API."""
+        callback1 = TestCallback()
+        callback2 = TestCallback2()
+        learner._add_callbacks([callback1, callback2])
+
+        learner.remove_callbacks([callback1, callback2])
+
+        assert callback1 not in learner.callbacks
+        assert callback2 not in learner.callbacks
+        assert not hasattr(learner, callback1.name)
+        assert not hasattr(learner, callback2.name)
 
     def test_callback_execution(self, learner):
         """Test callback execution order."""


### PR DESCRIPTION
## Summary
- Add public callback management helpers.
- Add fit_one_cycle as the documented scheduling helper.
- Align README and docs examples with the public learner API.