### PR TITLE
Harden data and callback behavior

### DIFF
--- a/cmn_ai/callbacks/core.py
+++ b/cmn_ai/callbacks/core.py
@@ -171,6 +171,7 @@ class Callback:
     """
 
     order: int = 0
+    learner: Any = None
 
     def __init__(self):
         """Initialize the callback."""

--- a/cmn_ai/callbacks/hook.py
+++ b/cmn_ai/callbacks/hook.py
@@ -116,7 +116,7 @@ class Hook:
                 partial(func, self, **kwargs)
             )
         else:
-            self.hook = module.register_backward_hook(
+            self.hook = module.register_full_backward_hook(
                 partial(func, self, **kwargs)
             )
 

--- a/cmn_ai/tabular/data.py
+++ b/cmn_ai/tabular/data.py
@@ -318,12 +318,22 @@ class DataSplitter:
         X = np.asarray(X) if not hasattr(X, "__getitem__") else X
         if y is not None and not hasattr(y, "__len__"):
             y = np.asarray(y)
+        if y is not None and len(X) != len(y):
+            raise ValueError("X and y must have the same length")
         return X, y
 
     def _infer_split_sizes(self, train_size, val_size, test_size):
         """
         Infer missing split sizes to ensure they sum to 1.0.
         """
+        for name, size in [
+            ("train", train_size),
+            ("val", val_size),
+            ("test", test_size),
+        ]:
+            if size is not None and not (0.0 < size < 1.0):
+                raise ValueError(f"{name}_size must be in (0, 1), got {size}")
+
         remainder = 1.0 - train_size
         if val_size is None and test_size is None:
             val_size = remainder / 2.0
@@ -337,6 +347,14 @@ class DataSplitter:
             raise ValueError(
                 "train_size + val_size + test_size must sum to 1.0"
             )
+
+        for name, size in [
+            ("train", train_size),
+            ("val", val_size),
+            ("test", test_size),
+        ]:
+            if not (0.0 < size < 1.0):
+                raise ValueError(f"{name}_size must be in (0, 1), got {size}")
 
         return train_size, val_size, test_size
 

--- a/cmn_ai/tabular/preprocessing.py
+++ b/cmn_ai/tabular/preprocessing.py
@@ -88,7 +88,10 @@ class DateTransformer(TransformerMixin, BaseEstimator):
     Attributes
     ----------
     date_feats : Iterable[str] | None, default=None
-        list of date feature column names to transform.
+        Date feature column names to transform. If None, they are learned
+        during fit and stored in `date_feats_`.
+    date_feats_ : list[str]
+        Learned date feature column names used during transformation.
     time : bool
         Whether to include time-related features (Hour, Minute, Second).
     drop : bool
@@ -174,9 +177,10 @@ class DateTransformer(TransformerMixin, BaseEstimator):
         """
         Fit the transformer by identifying date features.
 
-        This method populates the date_feats attribute if not provided at
+        This method populates the date_feats_ attribute if not provided at
         initialization. It scans the input dataframe for columns with
-        datetime64 data type and stores them for transformation.
+        datetime64 or timezone-aware datetime data type and stores them for
+        transformation.
 
         Parameters
         ----------
@@ -190,7 +194,7 @@ class DateTransformer(TransformerMixin, BaseEstimator):
         Returns
         -------
         self : DateTransformer
-            Fitted transformer instance with populated date_feats attribute.
+            Fitted transformer instance with populated date_feats_ attribute.
 
         Examples
         --------
@@ -201,11 +205,16 @@ class DateTransformer(TransformerMixin, BaseEstimator):
         ... })
         >>> transformer = DateTransformer()
         >>> fitted_transformer = transformer.fit(df)
-        >>> print(fitted_transformer.date_feats)
+        >>> print(fitted_transformer.date_feats_)
         ['date']
         """
-        if not self.date_feats:
-            self.date_feats = X.select_dtypes("datetime64").columns.tolist()
+        if self.date_feats is None:
+            self.date_feats_ = X.select_dtypes(
+                include=["datetime64[ns]", "datetimetz"]
+            ).columns.tolist()
+        else:
+            self.date_feats_ = list(self.date_feats)
+        self.feature_names_in_ = X.columns.to_numpy(dtype=object)
         return self
 
     def transform(
@@ -252,7 +261,7 @@ class DateTransformer(TransformerMixin, BaseEstimator):
         [1, 2]
         """
         X_tr = X.copy()
-        for col, attr in product(self.date_feats, self.attrs):
+        for col, attr in product(self.date_feats_, self.attrs):
             if attr == "Week" and hasattr(X_tr[col].dt, "isocalendar"):
                 X_tr[f"{col}_{attr}"] = (
                     X_tr[col]
@@ -261,8 +270,35 @@ class DateTransformer(TransformerMixin, BaseEstimator):
                 )
                 continue
             X_tr[f"{col}_{attr}"] = getattr(X_tr[col].dt, attr.lower())
-        for col in self.date_feats:
+        for col in self.date_feats_:
             X_tr[f"{col}_na_indicator"] = X_tr[col].isna().astype(np.int8)
         if self.drop:
-            return X_tr.drop(columns=self.date_feats)
+            return X_tr.drop(columns=self.date_feats_)
         return X_tr
+
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        """
+        Return output feature names for transformed data.
+
+        Parameters
+        ----------
+        input_features : array-like of str, optional
+            Input feature names. If None, uses feature names seen during fit.
+
+        Returns
+        -------
+        np.ndarray
+            Output feature names in the same order as `transform`.
+        """
+        if input_features is None:
+            input_features = self.feature_names_in_
+        names = list(input_features)
+        names.extend(
+            f"{col}_{attr}"
+            for col, attr in product(self.date_feats_, self.attrs)
+        )
+        names.extend(f"{col}_na_indicator" for col in self.date_feats_)
+
+        if self.drop:
+            names = [name for name in names if name not in self.date_feats_]
+        return np.asarray(names, dtype=object)

--- a/cmn_ai/utils/data.py
+++ b/cmn_ai/utils/data.py
@@ -85,7 +85,20 @@ from torch.utils.data import DataLoader, Dataset, default_collate
 from .processors import Processor
 from .utils import listify
 
-DEFAULT_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+def _default_device() -> str:
+    """Return the best available torch device."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if (
+        hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_available()
+    ):
+        return "mps"
+    return "cpu"
+
+
+DEFAULT_DEVICE = _default_device()
 
 
 def get_dls(

--- a/cmn_ai/utils/utils.py
+++ b/cmn_ai/utils/utils.py
@@ -300,7 +300,7 @@ def clean_memory() -> None:
     1. Cleaning traceback objects
     2. Clearing IPython history
     3. Running garbage collection
-    4. Emptying PyTorch's CUDA cache
+    4. Emptying available PyTorch device caches
 
     Notes
     -----
@@ -315,7 +315,14 @@ def clean_memory() -> None:
     clean_traceback()
     clean_ipython_history()
     gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    if (
+        hasattr(torch.backends, "mps")
+        and torch.backends.mps.is_available()
+        and hasattr(torch, "mps")
+    ):
+        torch.mps.empty_cache()
 
 
 def set_printoptions(

--- a/tests/test_callbacks/test_core.py
+++ b/tests/test_callbacks/test_core.py
@@ -100,15 +100,29 @@ class TestCallback:
 
     def test_getattr_without_learner(self):
         """Test __getattr__ when learner is not set."""
-        # This will cause recursion, so we'll skip this test
-        # The __getattr__ method will try to access self.learner.non_existent_attribute
-        # but self.learner is None, causing infinite recursion
-        pass
+        callback = Callback()
 
-    def test_getattr_learner_none(self):
-        """Test __getattr__ when learner is None."""
-        # This will cause recursion, so we'll skip this test
-        pass
+        with pytest.raises(
+            AttributeError,
+            match="'Callback' object has no attribute 'some_attribute'",
+        ):
+            _ = callback.some_attribute
+
+    def test_getattr_without_super_init_does_not_recurse(self):
+        """Test callbacks without super init still have a default learner."""
+
+        class NoSuperCallback(Callback):
+            def __init__(self):
+                self.value = "set"
+
+        callback = NoSuperCallback()
+
+        assert callback.learner is None
+        with pytest.raises(
+            AttributeError,
+            match="'NoSuperCallback' object has no attribute 'some_attribute'",
+        ):
+            _ = callback.some_attribute
 
     def test_name_property(self):
         """Test the name property returns class name."""

--- a/tests/test_callbacks/test_hook.py
+++ b/tests/test_callbacks/test_hook.py
@@ -66,10 +66,17 @@ class TestHook:
     def test_hook_register_backward(self):
         """Test registering a backward hook."""
         model = SimpleModel()
-        hook = Hook(model.linear1, compute_stats, is_forward=False)
+        hook_handle = MagicMock()
 
-        # Hook is automatically registered in __init__
-        assert hook.hook is not None
+        with patch.object(
+            model.linear1,
+            "register_full_backward_hook",
+            return_value=hook_handle,
+        ) as register_full_backward_hook:
+            hook = Hook(model.linear1, compute_stats, is_forward=False)
+
+        register_full_backward_hook.assert_called_once()
+        assert hook.hook is hook_handle
 
     def test_hook_remove(self):
         """Test hook removal."""

--- a/tests/test_callbacks/test_training.py
+++ b/tests/test_callbacks/test_training.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from cmn_ai.callbacks.core import CancelFitException
 from cmn_ai.callbacks.training import (
     BatchTransform,
+    DEFAULT_DEVICE,
     BatchTransformX,
     DeviceCallback,
     LRFinder,
@@ -55,7 +56,7 @@ class TestDeviceCallback:
     def test_device_callback_init_default(self):
         """Test DeviceCallback initialization with default device."""
         callback = DeviceCallback()
-        assert callback.device == "cpu"  # Assuming DEFAULT_DEVICE is 'cpu'
+        assert callback.device == DEFAULT_DEVICE
 
     def test_device_callback_before_fit(self):
         """Test DeviceCallback before_fit method."""

--- a/tests/test_tabular/test_data.py
+++ b/tests/test_tabular/test_data.py
@@ -215,6 +215,41 @@ class TestDataSplitting:
         with pytest.raises(ValueError, match="must sum to 1.0"):
             get_data_splits(X, y, train_size=0.5, val_size=0.3, test_size=0.3)
 
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            (
+                {"train_size": 1.0, "val_size": 0.1, "test_size": -0.1},
+                "train_size must be in \\(0, 1\\)",
+            ),
+            (
+                {"train_size": 0.8, "val_size": 0.0, "test_size": 0.2},
+                "val_size must be in \\(0, 1\\)",
+            ),
+            (
+                {"train_size": 0.8, "val_size": 0.3, "test_size": -0.1},
+                "test_size must be in \\(0, 1\\)",
+            ),
+        ],
+    )
+    def test_size_range_validation(self, kwargs, match):
+        """Test validation that each split size is in range."""
+        X = np.random.rand(20, 5)
+        y = np.random.choice([0, 1], size=20)
+
+        with pytest.raises(ValueError, match=match):
+            get_data_splits(X, y, stratify=False, **kwargs)
+
+    def test_mismatched_x_y_lengths_raise_clear_error(self):
+        """Test validation that X and y have the same length."""
+        X = np.random.rand(10, 5)
+        y = np.random.choice([0, 1], size=9)
+
+        with pytest.raises(
+            ValueError, match="X and y must have the same length"
+        ):
+            get_data_splits(X, y, stratify=False)
+
     def test_groups_with_stratify_error(self):
         """Test that groups with stratify raises an error."""
         X = np.random.rand(100, 5)

--- a/tests/test_tabular/test_preprocessing.py
+++ b/tests/test_tabular/test_preprocessing.py
@@ -79,7 +79,8 @@ class TestDateTransformer:
         transformer = DateTransformer()
         fitted_transformer = transformer.fit(self.df_with_dates)
 
-        assert fitted_transformer.date_feats == ["date"]
+        assert fitted_transformer.date_feats is None
+        assert fitted_transformer.date_feats_ == ["date"]
         assert fitted_transformer is transformer
 
     def test_fit_with_specified_features(self):
@@ -88,13 +89,18 @@ class TestDateTransformer:
         fitted_transformer = transformer.fit(self.df_with_dates)
 
         assert fitted_transformer.date_feats == ["date"]
+        assert fitted_transformer.date_feats_ == ["date"]
 
     def test_fit_with_multiple_dates(self):
         """Test fitting with multiple date columns."""
         transformer = DateTransformer()
         fitted_transformer = transformer.fit(self.df_multiple_dates)
 
-        assert set(fitted_transformer.date_feats) == {"start_date", "end_date"}
+        assert fitted_transformer.date_feats is None
+        assert set(fitted_transformer.date_feats_) == {
+            "start_date",
+            "end_date",
+        }
 
     def test_fit_with_no_dates(self):
         """Test fitting with dataframe containing no date columns."""
@@ -105,7 +111,38 @@ class TestDateTransformer:
         transformer = DateTransformer()
         fitted_transformer = transformer.fit(df_no_dates)
 
-        assert fitted_transformer.date_feats == []
+        assert fitted_transformer.date_feats is None
+        assert fitted_transformer.date_feats_ == []
+
+    def test_fit_relearns_auto_detected_features_without_mutating_param(self):
+        """Test repeated fit updates learned date features only."""
+        transformer = DateTransformer()
+        transformer.fit(self.df_with_dates)
+
+        df_other_dates = pd.DataFrame(
+            {
+                "other_date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+                "value": [1, 2],
+            }
+        )
+        transformer.fit(df_other_dates)
+
+        assert transformer.date_feats is None
+        assert transformer.date_feats_ == ["other_date"]
+
+    def test_fit_detects_timezone_aware_datetimes(self):
+        """Test fitting detects timezone-aware datetime columns."""
+        df_tz = pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=2, tz="UTC"),
+                "value": [1, 2],
+            }
+        )
+
+        transformer = DateTransformer()
+        transformer.fit(df_tz)
+
+        assert transformer.date_feats_ == ["date"]
 
     def test_transform_basic(self):
         """Test basic transformation without time features."""
@@ -210,6 +247,16 @@ class TestDateTransformer:
         assert "date_Year" in result.columns
         assert "date_Hour" in result.columns
         assert "date" not in result.columns
+
+    def test_get_feature_names_out_matches_transformed_columns(self):
+        """Test get_feature_names_out returns transformed dataframe columns."""
+        transformer = DateTransformer(time=False, drop=True)
+        transformer.fit(self.df_with_dates)
+        result = transformer.transform(self.df_with_dates)
+
+        assert transformer.get_feature_names_out().tolist() == list(
+            result.columns
+        )
 
     def test_get_params(self):
         """Test get_params method for scikit-learn compatibility."""

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+import cmn_ai.utils.data as data_utils
 from cmn_ai.utils.data import (
     ItemList,
     LabeledData,
@@ -31,6 +32,19 @@ from cmn_ai.utils.data import (
 
 class TestDeviceManagement:
     """Test device management functions."""
+
+    def test_default_device_prefers_mps_when_cuda_unavailable(
+        self, monkeypatch
+    ):
+        """Test default device selection supports Apple Silicon MPS."""
+        monkeypatch.setattr(
+            data_utils.torch.cuda, "is_available", lambda: False
+        )
+        monkeypatch.setattr(
+            data_utils.torch.backends.mps, "is_available", lambda: True
+        )
+
+        assert data_utils._default_device() == "mps"
 
     def test_to_device_tensor(self):
         """Test to_device with a single tensor."""

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+import cmn_ai.utils.utils as utils_mod
 from cmn_ai.utils.utils import listify, setify, tuplify, uniqueify
 
 
@@ -40,3 +43,37 @@ def test_uniqueify():
     assert uniqueify((1, 1)) == [1]
     assert uniqueify([1, -1, 3], True) == [-1, 1, 3]
     assert uniqueify((1.0, 2.0, -100), True)
+
+
+def test_clean_memory_clears_only_available_device_caches(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        utils_mod, "clean_traceback", lambda: calls.append("traceback")
+    )
+    monkeypatch.setattr(
+        utils_mod, "clean_ipython_history", lambda: calls.append("history")
+    )
+    monkeypatch.setattr(utils_mod.gc, "collect", lambda: calls.append("gc"))
+    monkeypatch.setattr(
+        utils_mod.torch.cuda, "is_available", lambda: False
+    )
+    monkeypatch.setattr(
+        utils_mod.torch.cuda, "empty_cache", lambda: calls.append("cuda")
+    )
+    monkeypatch.setattr(
+        utils_mod.torch.backends,
+        "mps",
+        SimpleNamespace(is_available=lambda: True),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        utils_mod.torch,
+        "mps",
+        SimpleNamespace(empty_cache=lambda: calls.append("mps")),
+        raising=False,
+    )
+
+    utils_mod.clean_memory()
+
+    assert calls == ["traceback", "history", "gc", "mps"]


### PR DESCRIPTION
## Summary
- Prevent callback learner lookup recursion.
- Validate tabular split inputs.
- Keep DateTransformer parameters immutable.
- Use full backward hooks and make device cleanup device-aware.
- Align device callback default behavior in tests.