### PR TITLE
Remove ListContainer abstraction

### DIFF
--- a/cmn_ai/utils/data.py
+++ b/cmn_ai/utils/data.py
@@ -28,7 +28,6 @@ label_by_func : Label split data using a labeling function
 Classes
 -------
 DataLoaders : Container for training and validation DataLoaders
-ListContainer : Extended list with improved representation
 ItemList : Base class for all types of datasets
 SplitData : Split ItemList into train and validation data lists
 LabeledData : Create labeled data with input and target ItemLists
@@ -89,10 +88,7 @@ def _default_device() -> str:
     """Return the best available torch device."""
     if torch.cuda.is_available():
         return "cuda"
-    if (
-        hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_available()
-    ):
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         return "mps"
     return "cpu"
 
@@ -465,48 +461,7 @@ def get_files(
         return _get_files(path, fs, extensions)
 
 
-class ListContainer(UserList):
-    """
-    Extended list with improved representation.
-
-    Extends builtin list by changing the creation of the list from the given
-    items and changing repr to return first 10 items along with total number of
-    items and the class name. This will be the base class where other
-    containers will inherit from.
-
-    Attributes
-    ----------
-    data : list
-        The underlying list data.
-
-    Examples
-    --------
-    >>> container = ListContainer([1, 2, 3, 4, 5])
-    >>> print(container)
-    ListContainer: (5 items)
-    [1, 2, 3, 4, 5]
-    """
-
-    def __init__(self, items: Any) -> None:
-        """
-        Initialize ListContainer with items.
-
-        Parameters
-        ----------
-        items : Any
-            Items to create list from.
-        """
-        self.data = listify(items)
-
-    def __repr__(self) -> str:
-        cls_nm = self.__class__.__name__
-        res = f"{cls_nm}: ({len(self.data) :,} items)\n{self.data[:10]}"  # noqa: E231
-        if len(self) > 10:
-            res = res[:-1] + ", ...]"
-        return res
-
-
-class ItemList(ListContainer):
+class ItemList(UserList):
     """
     Base class for all types of datasets such as image, text, etc.
 
@@ -529,7 +484,7 @@ class ItemList(ListContainer):
 
     def __init__(
         self,
-        items: Sequence,
+        items: Any,
         path: str | Path = ".",
         tfms: Callable | None = None,
         **kwargs,
@@ -539,7 +494,7 @@ class ItemList(ListContainer):
 
         Parameters
         ----------
-        items : Sequence
+        items : Any
             Items to create list.
         path : str or Path, default="."
             Path of the items that were used to create the list.
@@ -548,13 +503,17 @@ class ItemList(ListContainer):
         **kwargs : dict
             Additional attributes to set on the instance.
         """
-        super().__init__(items)
+        self.data = listify(items)
         self.path = Path(path)
         self.tfms = tfms
         self.__dict__.update(kwargs)
 
     def __repr__(self) -> str:
-        return super().__repr__() + f"\nPath: {self.path.resolve()}"
+        cls_nm = self.__class__.__name__
+        res = f"{cls_nm}: ({len(self.data) :,} items)\n{self.data[:10]}"  # noqa: E231
+        if len(self) > 10:
+            res = res[:-1] + ", ...]"
+        return res + f"\nPath: {self.path.resolve()}"
 
     def new(
         self, items: Sequence, cls: type[ItemList] | None = None

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -18,7 +18,6 @@ from cmn_ai.utils.data import (
     DataLoaders,
     ItemList,
     LabeledData,
-    ListContainer,
     SplitData,
     compose,
     get_files,
@@ -259,37 +258,6 @@ class TestSplitters:
         assert result == "dog"
 
 
-class TestListContainer:
-    """Test ListContainer class."""
-
-    def test_init_with_list(self):
-        """Test ListContainer initialization with list."""
-        items = [1, 2, 3, 4, 5]
-        container = ListContainer(items)
-        assert len(container) == 5
-        assert container.data == items
-
-    def test_init_with_single_item(self):
-        """Test ListContainer initialization with single item."""
-        container = ListContainer(42)
-        assert len(container) == 1
-        assert container.data == [42]
-
-    def test_repr_short_list(self):
-        """Test ListContainer repr with short list."""
-        container = ListContainer([1, 2, 3])
-        repr_str = repr(container)
-        assert "ListContainer: (3 items)" in repr_str
-        assert "[1, 2, 3]" in repr_str
-
-    def test_repr_long_list(self):
-        """Test ListContainer repr with long list."""
-        container = ListContainer(list(range(15)))
-        repr_str = repr(container)
-        assert "ListContainer: (15 items)" in repr_str
-        assert "..." in repr_str  # Should truncate
-
-
 class TestItemList:
     """Test ItemList class."""
 
@@ -299,8 +267,16 @@ class TestItemList:
         item_list = ItemList(items, path="./data")
 
         assert len(item_list) == 2
+        assert item_list.data == items
         assert item_list.path == Path("./data")
         assert item_list.tfms is None
+
+    def test_init_with_single_item(self):
+        """Test ItemList initialization with single item."""
+        item_list = ItemList(42)
+
+        assert len(item_list) == 1
+        assert item_list.data == [42]
 
     def test_init_with_transforms(self):
         """Test ItemList initialization with transforms."""
@@ -355,8 +331,18 @@ class TestItemList:
         item_list = ItemList(items, path="./data")
 
         repr_str = repr(item_list)
-        assert "ItemList" in repr_str
+        assert "ItemList: (2 items)" in repr_str
+        assert "['file1.txt', 'file2.txt']" in repr_str
         assert "Path:" in repr_str
+
+    def test_repr_long_list(self):
+        """Test ItemList repr truncates long lists."""
+        item_list = ItemList(list(range(15)))
+
+        repr_str = repr(item_list)
+
+        assert "ItemList: (15 items)" in repr_str
+        assert "..." in repr_str
 
 
 class TestSplitData:


### PR DESCRIPTION
## Summary
- Remove the standalone `ListContainer` abstraction.
- Move its `listify` initialization and truncated representation behavior directly into `ItemList`.
- Update `ItemList` tests to cover the retained single-item and representation behavior.